### PR TITLE
Customise views and include taxonomy links

### DIFF
--- a/templates/sitemap.xml.twig
+++ b/templates/sitemap.xml.twig
@@ -23,4 +23,17 @@
             </url>
         {% endif %}
     {% endfor %}
+
+    {% if taxonomies is defined %}
+        {% for taxonomy in taxonomies %}
+            {% if taxonomy|link is not empty %}
+                <url>
+                    <loc>{{ absolute_url(taxonomy|link) }}</loc>
+                    <changefreq>weekly</changefreq>
+                    <priority>0.7</priority>
+                    <lastmod>{{ "now"|date('Y-m-d\\TH:i:sP') }}</lastmod>
+                </url>
+            {% endif %}
+        {% endfor %}
+    {% endif %}
 </urlset>


### PR DESCRIPTION
There are 2 parts to this pull request.

### Part 1: custom views

First, I needed the ability to customise the links generated in the sitemap. My blog posts have a custom link (year/month/slug) instead of the default, so I have my own “blog_post_link” filter to generate these in place of the default “link”.

I couldn’t figure out if/how I could override the default sitemap.xml.twig. If I made my own Twig namespace called “sitemap” this was ignored - presumably because the module adds it dynamically in code. Copying the folder containing the templates into my theme folder equally didn’t work.

I’ve added the ability to specify alternative views to load with the “xml_view” and “xsl_view” config parameters. The defaults are used if these are not provided in the config so it’s backwards-compatible.

My config looks like this:

```
xml_view: "@andysh-uk/sitemap/sitemap.xml.twig"
xsl_view: "@andysh-uk/sitemap/sitemap.xsl"
```

And in my config/packages/twig.yaml under “paths”:

```
'%kernel.project_dir%/public/theme/andysh-uk/': 'andysh-uk'
```

I’ve copied the default themes from the sitemap templates folder into public/theme/andysh-uk/sitemap.

If there’s a better way for me to override the default templates, please let me know, and I’ll revert this.

### Part 2: links to taxonomy listings

I’ve added the ability to include “taxonomies: [‘categories’, ‘tags’]” in the config to also generate links to the taxonomy term listing pages - e.g.: https://andysh.uk/category/miscellaneous

This loops over each taxonomy specified and gets the terms for that taxonomy type from the database. It emits a second listing variable for Twig to render.

The controller doesn’t load any taxonomies if this config parameter isn’t present, so it’s backwards-compatible, and equally the Twig view doesn’t try to do anything with taxonomies if they have not been loaded.