### PR TITLE
Rename templates config

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,7 @@
 # Configuration file for the Sitemap extension.
 
 limit: 10000
-
-xml_view: "@sitemap/sitemap.xml.twig"
-xsl_view: "@sitemap/sitemap.xsl"
+templates:
+  xml: '@sitemap/sitemap.xml.twig'
+  xsl: '@sitemap/sitemap.xsl'
+#taxonomies: ['categories', 'tags']

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,6 +2,6 @@
 
 limit: 10000
 templates:
-  xml: '@sitemap/sitemap.xml.twig'
-  xsl: '@sitemap/sitemap.xsl'
-#taxonomies: ['categories', 'tags']
+  xml: "@sitemap/sitemap.xml.twig"
+  xsl: "@sitemap/sitemap.xsl"
+#taxonomies: ["categories", "tags"]

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -47,8 +47,8 @@ class Controller extends ExtensionController
 
         $headerContentType = 'text/xml;charset=UTF-8';
 
-        $view = isset($config['xml_view'])
-            ? $config['xml_view']
+        $view = isset($config['templates']['xml'])
+            ? $config['templates']['xml']
             : '@sitemap/sitemap.xml.twig';
 
         $response = $this->render($view, $context);
@@ -62,8 +62,8 @@ class Controller extends ExtensionController
         $headerContentType = 'text/xml;charset=UTF-8';
 
         $config = $this->getConfig();
-        $view = isset($config['xsl_view'])
-            ? $config['xsl_view']
+        $view = isset($config['templates']['xsl'])
+            ? $config['templates']['xsl']
             : '@sitemap/sitemap.xsl';
 
         $response = $this->render($view);


### PR DESCRIPTION
Following on from PR #3, the template parameters I added previously are now under a `templates` node:

```yaml
templates:
  xml: '@sitemap/sitemap.xml.twig'
  xsl: '@sitemap/sitemap.xsl'
```

I've also added a sample config to include the taxonomy pages (but left commented out):

```yaml
#taxonomies: ['categories', 'tags']
```