### PR TITLE
Add record image not to listing entry

### DIFF
--- a/templates/sitemap.xml.twig
+++ b/templates/sitemap.xml.twig
@@ -9,6 +9,7 @@
 >
     {%- set lastContentTypeSlug = null -%}
     {%- for record in records -%}
+        {%- set isListing = false -%}
         {% if showListings %}
             {%- set contentType = record.definition -%}
             {%- if lastContentTypeSlug != contentType.slug and not contentType.viewless_listing -%}
@@ -18,13 +19,15 @@
                     {%- set lastContentTypeSlug = contentType.slug -%}
                     {%- set url = path('listing', { contentTypeSlug: contentType.slug }) -%}
                     {%- set priority = 0.8 -%}
+                    {%- set isListing = true -%}
                     {{ block('urlBlock') }}
+                    {%- set isListing = false -%}
 
                 {%- endif -%}
 
             {%- endif -%}
         {%- endif -%}
-        {%- if record|link is not empty -%}
+        {%- if if not isListing and record|link is not empty -%}
             {%- set url = record|link -%}
             {%- set priority = 0.8 -%}
             {{ block('urlBlock') }}


### PR DESCRIPTION
When `showListings` is enabled, the listing got the image from the record from which the listing was generated.

This code is preventing this behaviour. No image is added to the listing entry in the sitemap.