### PR TITLE
Allow records to be excluded

### DIFF
--- a/templates/sitemap.xml.twig
+++ b/templates/sitemap.xml.twig
@@ -9,8 +9,8 @@
 >
     {%- set lastContentTypeSlug = null -%}
     {%- for record in records -%}
+        {%- set contentType = record.definition -%}
         {% if showListings %}
-            {%- set contentType = record.definition -%}
             {%- if lastContentTypeSlug != contentType.slug and not contentType.viewless_listing -%}
 
                 {%- if (contentType.hide_listing_from_xml_sitemap is not defined) or (not contentType.hide_listing_from_xml_sitemap) -%}
@@ -25,9 +25,11 @@
             {%- endif -%}
         {%- endif -%}
         {%- if record|link is not empty -%}
-            {%- set url = record|link -%}
-            {%- set priority = 0.8 -%}
-            {{ block('urlBlock') }}
+            {%- if (contentType.hide_records_from_xml_sitemap is not defined) or (not contentType.hide_records_from_xml_sitemap) -%}
+                {%- set url = record|link -%}
+                {%- set priority = 0.8 -%}
+                {{ block('urlBlock') }}
+            {%- endif -%}
         {%- endif -%}
     {%- endfor -%}
 


### PR DESCRIPTION
I needed the ability to exclude records from the sitemap without setting `viewless: true`. This code is implemented like the code from [this pull request](https://github.com/bobdenotter/sitemap/pull/6) to disable listings in the sitemap.

Example contentType definition in contenttypes.yaml:

```
pages:
    hide_records_from_xml_sitemap: true
```
